### PR TITLE
Delete .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-* text=auto


### PR DESCRIPTION
No need for `.gitattributes` if only configuring auto.